### PR TITLE
Address #1 - extend docs for local execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,26 +97,29 @@ cluster_average(adata,sample_name="your_sample_name")
 ```
 ## Run CellAnn on your local computer
 
-1. Download the `CellAnn_shinyapp-main.zip` file and unzip. In a *nix system (macOS or Linux), you can achieve this in the command line as follows:
+1. Clone this repository.
 
+2. `cd` to into the new clone. Initialize Git LFS 
 ```bash
-cd /path/to/download/dir
-unzip CellAnn_shinyapp-main.zip
+git lfs install
 ```
-
-2. `cd` to your unzip folder (`CellAnn_shinyapp-main`) and unzip the `CellAnn_version1.0.zip` file. This file is compressed with the LZMA algorithm, therefore, you will need to use a program like [7z](https://www.7-zip.org/download.html) to decompress it. In a *nix system, you can achieve this with a command like this:
+3. Fetch LFS objects
+```bash
+git lfs pull
+```
+4. Unzip the `CellAnn_version1.0.zip` file. This file is compressed with the LZMA algorithm, therefore, you will need to use a program like [7z](https://www.7-zip.org/download.html) to decompress it. In a *nix system, you can achieve this with a command like this:
 
 ```bash
 7z x CellAnn_version1.0.zip
 ```
 
-3. Install CellAnn dependencies:
+5. Install CellAnn dependencies:
 
 ```bash
 R -e "install.packages(c('shiny', 'shinyBS', 'DT', 'ggplot2', 'plotly', 'shinyjs', 'data.table', 'tibble', 'stringr', 'shinyFeedback', 'tibble', 'limma', 'pcaPP', 'shinyWidgets', 'bslib', 'shinybusy', 'markdown', 'BiocManager')); BiocManager::install('limma')"
 ```
 
-4. cd to your unzip folder (Cell_Ann_bioinfo) and run the webserver on your local computer with the following commands:
+6. cd to your unzip folder (Cell_Ann_bioinfo) and run the webserver on your local computer with the following commands:
 
 ```shell
 cd /your_unzip_path/Cell_Ann_bioinfo

--- a/README.md
+++ b/README.md
@@ -95,17 +95,32 @@ def cluster_average(adata,sample_name):
 cluster_average(adata,sample_name="your_sample_name")
 
 ```
-## run CellAnn on your local computer
+## Run CellAnn on your local computer
 
-1. Download the CellAnn_shinyapp-main.zip file and unzip.
+1. Download the `CellAnn_shinyapp-main.zip` file and unzip. In a *nix system (macOS or Linux), you can achieve this in the command line as follows:
 
-2. cd to your unzip folder (CellAnn_shinyapp-main) and unzip the CellAnn_version1.0.zip file.
+```bash
+cd /path/to/download/dir
+unzip CellAnn_shinyapp-main.zip
+```
 
-3. cd to your unzip folder (Cell_Ann_bioinfo) and run the webserver on your local computer with the following commands:
+2. `cd` to your unzip folder (`CellAnn_shinyapp-main`) and unzip the `CellAnn_version1.0.zip` file. This file is compressed with the LZMA algorithm, therefore, you will need to use a program like [7z](https://www.7-zip.org/download.html) to decompress it. In a *nix system, you can achieve this with a command like this:
+
+```bash
+7z x CellAnn_version1.0.zip
+```
+
+3. Install CellAnn dependencies:
+
+```bash
+R -e "install.packages(c('shiny', 'shinyBS', 'DT', 'ggplot2', 'plotly', 'shinyjs', 'data.table', 'tibble', 'stringr', 'shinyFeedback', 'tibble', 'limma', 'pcaPP', 'shinyWidgets', 'bslib', 'shinybusy', 'markdown', 'BiocManager')); BiocManager::install('limma')"
+```
+
+4. cd to your unzip folder (Cell_Ann_bioinfo) and run the webserver on your local computer with the following commands:
 
 ```shell
 cd /your_unzip_path/Cell_Ann_bioinfo
-R -e "shiny::runApp('~/')"
+R -e "shiny::runApp('.')"
 ```
 
 ### Note 


### PR DESCRIPTION
Hello,

I got the webserver running locally. I took the liberty to extend the docs with the steps I followed. 

The less obvious thing was that the `CellAnn_version1.0.zip` had been compressed with an algorithm different than the one the normal `unzip` command uses.

Hope this helps! 
Best,

Francesco